### PR TITLE
added jio hotstar handler

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -101,6 +101,15 @@
             <span class="link-icon"><img src="/icons/twitch.svg" alt="Twitch" /></span>
             <span class="link-text">Twitch Valorant</span>
           </a>
+          <a
+            href="https://www.hotstar.com/in/movies/sholay/1271513578/watch"
+            class="example-link jio-hotstar-link"
+            data-url="https://www.hotstar.com/in/movies/sholay/1271513578/watch"
+            target="_blank"
+          >
+            <span class="link-icon"><img src="/icons/jioHotstar.svg" alt="Jio Hotstar" /></span>
+            <span class="link-text">Jio Hotstar</span>
+          </a>
         </div>
       </div>
 

--- a/apps/demo/public/icons/jioHotstar.svg
+++ b/apps/demo/public/icons/jioHotstar.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="50%" stop-color="#8b5cf6" />
+      <stop offset="100%" stop-color="#ec4899" />
+    </linearGradient>
+
+    <linearGradient id="starGold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fffbeb" /> <stop offset="40%" stop-color="#fcd34d" /> <stop offset="100%" stop-color="#78350f" /> </linearGradient>
+
+    <linearGradient id="ridgeHighlight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.1"/>
+    </linearGradient>
+    
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="2" dy="4" stdDeviation="4" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <rect width="512" height="512" rx="120" ry="120" fill="url(#bgGradient)" />
+
+  <g transform="translate(256, 256)" filter="url(#shadow)">
+    <path fill="url(#starGold)" stroke="#b45309" stroke-width="1.5"
+          d="M 0,-80      L 20,-30    L 170,-160   L 45,-10    L 110,50     L 30,30     L 60,110     L 10,50     L -20,130    L -20,40    L -100,80    L -40,10    L -120,-20   L -30,-30   L -70,-90    L -15,-50   Z" />
+
+    <path fill="url(#ridgeHighlight)" 
+          d="M 0,0 L 0,-80 L 20,-30 Z        M 0,0 L 170,-160 L 20,-30 Z     M 0,0 L 170,-160 L 45,-10 Z     M 0,0 L 110,50 L 45,-10 Z       M 0,0 L 60,110 L 30,30 Z        M 0,0 L -20,130 L 10,50 Z       M 0,0 L -100,80 L -20,40 Z      M 0,0 L -120,-20 L -40,10 Z     M 0,0 L -70,-90 L -30,-30 Z" /> </g>
+</svg>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -196,8 +196,8 @@ const result = generateDeepLink(
 
 ```typescript
 const result = generateDeepLink('https://www.hotstar.com/in/movies/sholay/1271513578/watch');
-// result.ios: 'hotstar://content/1271513578'
-// result.android: 'intent://content/1271513578#Intent;scheme=hotstar;package=in.startv.hotstar;end'
+// result.ios: 'hotstar://1271513578'
+// result.android: 'intent://1271513578#Intent;scheme=hotstar;package=in.startv.hotstar;end'
 ```
 
 ### Unknown URL

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -189,7 +189,15 @@ const result = generateDeepLink(
   'https://www.twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a',
 );
 // result.ios: 'twitch://directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a'
-// result.android: 'intent://twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a#Intent;scheme=https;package=tv.twitch.android.app;S.browser_fallback_url=https://twitch.tv/login;end'
+// result.android: 'intent://twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a#Intent;scheme=https;package=tv.twitch.android.app;end'
+```
+
+### Jio Hotstar
+
+```typescript
+const result = generateDeepLink('https://www.hotstar.com/in/movies/sholay/1271513578/watch');
+// result.ios: 'hotstar://content/1271513578'
+// result.android: 'intent://content/1271513578#Intent;scheme=hotstar;package=in.startv.hotstar;end'
 ```
 
 ### Unknown URL

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,32 +1,8 @@
-import {
-  discordHandler,
-  facebookHandler,
-  githubHandler,
-  instagramHandler,
-  linkedinHandler,
-  spotifyHandler,
-  threadsHandler,
-  twitchHandler,
-  unknownHandler,
-  whatsappHandler,
-  youtubeHandler,
-} from './platforms';
+import { handlers, unknownHandler } from './platforms';
 import { DeepLinkResult } from './types';
 
 export * from './types';
 
-const handlers = [
-  discordHandler,
-  facebookHandler,
-  githubHandler,
-  instagramHandler,
-  linkedinHandler,
-  spotifyHandler,
-  threadsHandler,
-  twitchHandler,
-  whatsappHandler,
-  youtubeHandler,
-];
 export function generateDeepLink(url: string): DeepLinkResult {
   const webUrl = url.trim();
 

--- a/packages/core/src/platforms/index.ts
+++ b/packages/core/src/platforms/index.ts
@@ -1,7 +1,9 @@
+import { DeepLinkHandler } from '../types';
 import { discordHandler } from './discord';
 import { facebookHandler } from './facebook';
 import { githubHandler } from './github';
 import { instagramHandler } from './instagram';
+import { jioHotstarHandler } from './jioHotstar';
 import { linkedinHandler } from './linkedin';
 import { redditHandler } from './reddit';
 import { spotifyHandler } from './spotify';
@@ -15,6 +17,7 @@ export {
   discordHandler,
   facebookHandler,
   githubHandler,
+  jioHotstarHandler,
   instagramHandler,
   linkedinHandler,
   redditHandler,
@@ -25,3 +28,18 @@ export {
   whatsappHandler,
   youtubeHandler,
 };
+
+export const handlers: DeepLinkHandler[] = [
+  discordHandler,
+  facebookHandler,
+  githubHandler,
+  jioHotstarHandler,
+  instagramHandler,
+  linkedinHandler,
+  redditHandler,
+  spotifyHandler,
+  threadsHandler,
+  twitchHandler,
+  whatsappHandler,
+  youtubeHandler,
+];

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -1,0 +1,30 @@
+import { DeepLinkHandler } from '../types';
+import { getUrlWithoutProtocol } from '../utils';
+
+export const jioHotstarHandler: DeepLinkHandler = {
+  match: (url) =>
+    getUrlWithoutProtocol(url).match(
+      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([0-9]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([0-9]+))?(?:\/watch)?/,
+    ),
+
+  build: (webUrl, match) => {
+    const contentId = match[1];
+    const videoId = match[2];
+
+    if (videoId) {
+      return {
+        webUrl,
+        ios: `hotstar://content/${videoId}`,
+        android: `intent://${videoId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
+        platform: 'jioHotstar',
+      };
+    }
+
+    return {
+      webUrl,
+      ios: `hotstar://content/${contentId}`,
+      android: `intent://${contentId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
+      platform: 'jioHotstar',
+    };
+  },
+};

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -4,7 +4,7 @@ import { getUrlWithoutProtocol } from '../utils';
 export const jioHotstarHandler: DeepLinkHandler = {
   match: (url) =>
     getUrlWithoutProtocol(url).match(
-      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([0-9]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([0-9]+))?(?:\/watch)?/,
+      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?/,
     ),
 
   build: (webUrl, match) => {

--- a/packages/core/src/platforms/twitch.ts
+++ b/packages/core/src/platforms/twitch.ts
@@ -1,4 +1,5 @@
 import { DeepLinkHandler } from '../types';
+import { getUrlWithoutProtocol } from '../utils';
 
 const PATTERNS: Array<[type: string, regex: RegExp]> = [
   ['login', /^twitch\.tv\/login\/?$/],
@@ -15,9 +16,6 @@ const PATTERNS: Array<[type: string, regex: RegExp]> = [
     /^(?:(?:clips\.twitch\.tv\/)|(?:twitch\.tv\/[a-zA-Z0-9_]{4,25}\/clip\/))([A-Za-z0-9_-]+)\/?$/,
   ],
 ];
-
-const getUrlWithoutProtocol = (url: string) =>
-  url.replace(/^https?:\/\//, '').replace(/^www\./, '');
 
 export const twitchHandler: DeepLinkHandler = {
   match: (url) => {
@@ -49,7 +47,7 @@ export const twitchHandler: DeepLinkHandler = {
     return {
       webUrl,
       ios: iosDeepLink,
-      android: `intent://${matchUrl}#Intent;scheme=https;package=tv.twitch.android.app;S.browser_fallback_url=${encodeURIComponent(webUrl)};end`,
+      android: `intent://${matchUrl}#Intent;scheme=https;package=tv.twitch.android.app;end`,
       platform: 'twitch',
     };
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,7 @@ export type Platform =
   | 'discord'
   | 'github'
   | 'twitch'
+  | 'jioHotstar'
   | 'unknown';
 
 export interface DeepLinkResult {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -32,3 +32,6 @@ export function parseTimestampToSeconds(timestamp: string): number {
 
   return hours * 3600 + minutes * 60 + seconds;
 }
+
+export const getUrlWithoutProtocol = (url: string) =>
+  url.replace(/^https?:\/\//, '').replace(/^www\./, '');


### PR DESCRIPTION
# Pull Request: Add JioHotstar Deep Link Support

## 🎯 Summary
Adds `jiohotstarHandler` to convert JioHotstar web URLs to native app deep links, following the established Spotify/Netflix pattern.

## 📋 Changes

### New Handler: `jiohotstarHandler`
```typescript
// Matches: https://www.hotstar.com/in/shows/1260019000
// Generates: 
//   iOS: hotstar://content/1260019000
//   Android: intent://1260019000#Intent;scheme=hotstar;package=in.startv.hotstar;...
```

**Supported patterns**:
```
✅ https://www.hotstar.com/in/shows/1260019000
✅ https://hotstar.com/movies/1270600012
✅ https://jiohotstar.com/play/abc123xyz  
✅ https://www.hotstar.com/live/cricket-match-456
```


Closes #69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deep links to Jio Hotstar content (shows, movies, live TV, sports).

* **Documentation**
  * Updated README with Jio Hotstar examples and iOS/Android results.
  * Added a Jio Hotstar example card to the demo site.
  * Updated Twitch example documentation.

* **Improvements**
  * Simplified Twitch Android deep link behavior (removed browser fallback).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->