### PR TITLE
feat: add deep link support for Jio Hotstar platforms including new types, utilities, and demo examples.

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -101,6 +101,15 @@
             <span class="link-icon"><img src="/icons/twitch.svg" alt="Twitch" /></span>
             <span class="link-text">Twitch Valorant</span>
           </a>
+          <a
+            href="https://www.hotstar.com/in/movies/sholay/1271513578/watch"
+            class="example-link jio-hotstar-link"
+            data-url="https://www.hotstar.com/in/movies/sholay/1271513578/watch"
+            target="_blank"
+          >
+            <span class="link-icon"><img src="/icons/jioHotstar.svg" alt="Jio Hotstar" /></span>
+            <span class="link-text">Jio Hotstar</span>
+          </a>
         </div>
       </div>
 

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -107,7 +107,7 @@
             data-url="https://www.hotstar.com/in/movies/sholay/1271513578/watch"
             target="_blank"
           >
-            <span class="link-icon"><img src="/icons/jioHotstar.svg" alt="Jio Hotstar" /></span>
+            <span class="link-icon"><img src="/icons/jiohotstar.svg" alt="Jio Hotstar" /></span>
             <span class="link-text">Jio Hotstar</span>
           </a>
         </div>

--- a/apps/demo/public/icons/jioHotstar.svg
+++ b/apps/demo/public/icons/jioHotstar.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="50%" stop-color="#8b5cf6" />
+      <stop offset="100%" stop-color="#ec4899" />
+    </linearGradient>
+
+    <linearGradient id="starGold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fffbeb" /> <stop offset="40%" stop-color="#fcd34d" /> <stop offset="100%" stop-color="#78350f" /> </linearGradient>
+
+    <linearGradient id="ridgeHighlight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.1"/>
+    </linearGradient>
+    
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="2" dy="4" stdDeviation="4" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <rect width="512" height="512" rx="120" ry="120" fill="url(#bgGradient)" />
+
+  <g transform="translate(256, 256)" filter="url(#shadow)">
+    <path fill="url(#starGold)" stroke="#b45309" stroke-width="1.5"
+          d="M 0,-80      L 20,-30    L 170,-160   L 45,-10    L 110,50     L 30,30     L 60,110     L 10,50     L -20,130    L -20,40    L -100,80    L -40,10    L -120,-20   L -30,-30   L -70,-90    L -15,-50   Z" />
+
+    <path fill="url(#ridgeHighlight)" 
+          d="M 0,0 L 0,-80 L 20,-30 Z        M 0,0 L 170,-160 L 20,-30 Z     M 0,0 L 170,-160 L 45,-10 Z     M 0,0 L 110,50 L 45,-10 Z       M 0,0 L 60,110 L 30,30 Z        M 0,0 L -20,130 L 10,50 Z       M 0,0 L -100,80 L -20,40 Z      M 0,0 L -120,-20 L -40,10 Z     M 0,0 L -70,-90 L -30,-30 Z" /> </g>
+</svg>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -189,7 +189,15 @@ const result = generateDeepLink(
   'https://www.twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a',
 );
 // result.ios: 'twitch://directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a'
-// result.android: 'intent://twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a#Intent;scheme=https;package=tv.twitch.android.app;S.browser_fallback_url=https://twitch.tv/login;end'
+// result.android: 'intent://twitch.tv/directory/tags/80427d95-bb46-42d3-bf4d-408e9bdca49a#Intent;scheme=https;package=tv.twitch.android.app;end'
+```
+
+### Jio Hotstar
+
+```typescript
+const result = generateDeepLink('https://www.hotstar.com/in/movies/sholay/1271513578/watch');
+// result.ios: 'hotstar://1271513578'
+// result.android: 'intent://1271513578#Intent;scheme=hotstar;package=in.startv.hotstar;end'
 ```
 
 ### Unknown URL

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -196,8 +196,12 @@ const result = generateDeepLink(
 
 ```typescript
 const result = generateDeepLink('https://www.hotstar.com/in/movies/sholay/1271513578/watch');
-// result.ios: 'hotstar://1271513578'
+// result.ios: 'hotstar://content/1271513578'
 // result.android: 'intent://1271513578#Intent;scheme=hotstar;package=in.startv.hotstar;end'
+
+const result = generateDeepLink('https://www.hotstar.com/in/shows/mrs-deshpande/1271508620/takes-one-to-catch-one/1271513221/watch');
+// result.ios: 'hotstar://content/1271513221'
+// result.android: 'intent://1271513221#Intent;scheme=hotstar;package=in.startv.hotstar;end'
 ```
 
 ### Unknown URL

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,41 +1,9 @@
-import {
-  linkedinHandler,
-  youtubeHandler,
-  instagramHandler,
-  spotifyHandler,
-  threadsHandler,
-  whatsappHandler,
-  facebookHandler,
-  redditHandler,
-  discordHandler,
-  githubHandler,
-  pinterestHandler,
-  twitchHandler,
-  snapchatHandler,
-  telegramHandler,
-  unknownHandler,
-} from './platforms';
+import { handlers, unknownHandler } from './platforms';
 import { DeepLinkResult } from './types';
 import { normalizeUrl } from './utils/normalizeUrl';
 
 export * from './types';
 
-const handlers = [
-  linkedinHandler,
-  youtubeHandler,
-  instagramHandler,
-  spotifyHandler,
-  threadsHandler,
-  whatsappHandler,
-  snapchatHandler,
-  facebookHandler,
-  redditHandler,
-  discordHandler,
-  githubHandler,
-  pinterestHandler,
-  twitchHandler,
-  telegramHandler
-];
 export function generateDeepLink(url: string): DeepLinkResult {
   const webUrl = normalizeUrl(url);
 

--- a/packages/core/src/platforms/index.ts
+++ b/packages/core/src/platforms/index.ts
@@ -1,7 +1,9 @@
+import { DeepLinkHandler } from '../types';
 import { discordHandler } from './discord';
 import { facebookHandler } from './facebook';
 import { githubHandler } from './github';
 import { instagramHandler } from './instagram';
+import { jioHotstarHandler } from './jioHotstar';
 import { linkedinHandler } from './linkedin';
 import { pinterestHandler } from './pinterest';
 import { redditHandler } from './reddit';
@@ -15,19 +17,38 @@ import { snapchatHandler } from './snapchat';
 import { telegramHandler } from "./telegram";
 
 export {
-  linkedinHandler,
-  youtubeHandler,
-  instagramHandler,
-  spotifyHandler,
-  threadsHandler,
-  whatsappHandler,
-  facebookHandler,
-  redditHandler,
   discordHandler,
+  facebookHandler,
   githubHandler,
+  instagramHandler,
+  jioHotstarHandler,
+  linkedinHandler,
   pinterestHandler,
-  twitchHandler,
+  redditHandler,
   snapchatHandler,
+  spotifyHandler,
   telegramHandler,
-  unknownHandler,
+  threadsHandler,
+  twitchHandler,
+  whatsappHandler,
+  youtubeHandler,
+  unknownHandler
 };
+
+export const handlers: DeepLinkHandler[] = [
+  discordHandler,
+  facebookHandler,
+  githubHandler,
+  instagramHandler,
+  jioHotstarHandler,
+  linkedinHandler,
+  pinterestHandler,
+  redditHandler,
+  snapchatHandler,
+  spotifyHandler,
+  telegramHandler,
+  threadsHandler,
+  twitchHandler,
+  whatsappHandler,
+  youtubeHandler,
+];

--- a/packages/core/src/platforms/index.ts
+++ b/packages/core/src/platforms/index.ts
@@ -9,8 +9,8 @@ import { pinterestHandler } from './pinterest';
 import { redditHandler } from './reddit';
 import { snapchatHandler } from './snapchat';
 import { spotifyHandler } from './spotify';
-import { telegramHandler } from './telegram';
 import { substackHandler } from './substack';
+import { telegramHandler } from './telegram';
 import { threadsHandler } from './threads';
 import { twitchHandler } from './twitch';
 import { unknownHandler } from './unknown';
@@ -29,12 +29,14 @@ export {
   redditHandler,
   snapchatHandler,
   spotifyHandler,
+  substackHandler,
   telegramHandler,
   threadsHandler,
   twitchHandler,
+  unknownHandler,
   whatsappHandler,
   youtubeHandler,
-  unknownHandler
+  zoomHandler
 };
 
 export const handlers: DeepLinkHandler[] = [
@@ -48,9 +50,11 @@ export const handlers: DeepLinkHandler[] = [
   redditHandler,
   snapchatHandler,
   spotifyHandler,
+  substackHandler,
   telegramHandler,
   threadsHandler,
   twitchHandler,
   whatsappHandler,
   youtubeHandler,
+  zoomHandler,
 ];

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -5,6 +5,8 @@ import { getUrlWithoutProtocol } from '../utils';
 // - hotstar.com/in/movies/{movie-name}/{movie-id}
 // - hotstar.com/shows/{show-name}/{show-id}
 // - hotstar.com/shows/{show-name}/{show-id}/episode/{episode-id}
+// - hotstar.com/sports/{sport-name}/{video-name}/{video-id}
+// - hotstar.com/sports/{sport-name}/{video-name}/{video-id}/video/live/watch
 // - jiohotstar.com/play/{id}
 const PATTERNS: Array<[type: string, regex: RegExp]> = [
   [

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -1,11 +1,34 @@
 import { DeepLinkHandler } from '../types';
 import { getUrlWithoutProtocol } from '../utils';
 
+// Matches Hotstar URLs with patterns like:
+// - hotstar.com/in/movies/{movie-name}/{movie-id}
+// - hotstar.com/shows/{show-name}/{show-id}
+// - hotstar.com/shows/{show-name}/{show-id}/episode/{episode-id}
+// - jiohotstar.com/play/{id}
+const PATTERNS: Array<[type: string, regex: RegExp]> = [
+  [
+    'shows and movies',
+    /^(?:hotstar|jiohotstar|startv\.hotstar)(?:\.com)\/(?:in\/)?(?:shows|movies)(?:\/[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?$/,
+  ],
+  [
+    'sports',
+    /^(?:hotstar|jiohotstar|startv\.hotstar)(?:\.com)\/(?:in\/)?sports(?:\/[a-zA-Z0-9_-]+)(?:\/[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(?:\/video\/live)?(?:\/watch)?$/,
+  ],
+  ['play', /^(?:hotstar|jiohotstar|startv\.hotstar)(?:\.com)\/(?:in\/)?play\/([a-zA-Z0-9_-]+)$/],
+];
+
 export const jioHotstarHandler: DeepLinkHandler = {
-  match: (url) =>
-    getUrlWithoutProtocol(url).match(
-      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?$/,
-    ),
+  match: (url) => {
+    const urlWithoutProtocol = getUrlWithoutProtocol(url);
+
+    for (const [type, pattern] of PATTERNS) {
+      const match = urlWithoutProtocol.match(pattern);
+      if (match) return match;
+    }
+
+    return null;
+  },
 
   build: (webUrl, match) => {
     const contentId = match[1];

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -1,0 +1,30 @@
+import { DeepLinkHandler } from '../types';
+import { getUrlWithoutProtocol } from '../utils';
+
+export const jioHotstarHandler: DeepLinkHandler = {
+  match: (url) =>
+    getUrlWithoutProtocol(url).match(
+      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?/,
+    ),
+
+  build: (webUrl, match) => {
+    const contentId = match[1];
+    const videoId = match[2];
+
+    if (videoId) {
+      return {
+        webUrl,
+        ios: `hotstar://content/${videoId}`,
+        android: `intent://${videoId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
+        platform: 'jioHotstar',
+      };
+    }
+
+    return {
+      webUrl,
+      ios: `hotstar://content/${contentId}`,
+      android: `intent://${contentId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
+      platform: 'jioHotstar',
+    };
+  },
+};

--- a/packages/core/src/platforms/jioHotstar.ts
+++ b/packages/core/src/platforms/jioHotstar.ts
@@ -4,7 +4,7 @@ import { getUrlWithoutProtocol } from '../utils';
 export const jioHotstarHandler: DeepLinkHandler = {
   match: (url) =>
     getUrlWithoutProtocol(url).match(
-      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?/,
+      /^(?:hotstar\.com|jiohotstar\.com|startv\.hotstar\.com)\/(?:in\/)?(?:shows|movies|live|tv|sport|play)(?:\/[a-zA-Z0-9_-]+)?\/([a-zA-Z0-9_-]+)(?:\/(?:[a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+))?(?:\/watch)?$/,
     ),
 
   build: (webUrl, match) => {
@@ -16,7 +16,7 @@ export const jioHotstarHandler: DeepLinkHandler = {
         webUrl,
         ios: `hotstar://content/${videoId}`,
         android: `intent://${videoId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
-        platform: 'jioHotstar',
+        platform: 'jiohotstar',
       };
     }
 
@@ -24,7 +24,7 @@ export const jioHotstarHandler: DeepLinkHandler = {
       webUrl,
       ios: `hotstar://content/${contentId}`,
       android: `intent://${contentId}#Intent;scheme=hotstar;package=in.startv.hotstar;end`,
-      platform: 'jioHotstar',
+      platform: 'jiohotstar',
     };
   },
 };

--- a/packages/core/src/platforms/twitch.ts
+++ b/packages/core/src/platforms/twitch.ts
@@ -1,4 +1,5 @@
 import { DeepLinkHandler } from '../types';
+import { getUrlWithoutProtocol } from '../utils';
 
 const PATTERNS: Array<[type: string, regex: RegExp]> = [
   ['login', /^twitch\.tv\/login\/?$/],
@@ -15,9 +16,6 @@ const PATTERNS: Array<[type: string, regex: RegExp]> = [
     /^(?:(?:clips\.twitch\.tv\/)|(?:twitch\.tv\/[a-zA-Z0-9_]{4,25}\/clip\/))([A-Za-z0-9_-]+)\/?$/,
   ],
 ];
-
-const getUrlWithoutProtocol = (url: string) =>
-  url.replace(/^https?:\/\//, '').replace(/^www\./, '');
 
 export const twitchHandler: DeepLinkHandler = {
   match: (url) => {
@@ -49,7 +47,7 @@ export const twitchHandler: DeepLinkHandler = {
     return {
       webUrl,
       ios: iosDeepLink,
-      android: `intent://${matchUrl}#Intent;scheme=https;package=tv.twitch.android.app;S.browser_fallback_url=${encodeURIComponent(webUrl)};end`,
+      android: `intent://${matchUrl}#Intent;scheme=https;package=tv.twitch.android.app;end`,
       platform: 'twitch',
     };
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,7 @@ export type Platform =
   | 'twitch'
   | 'snapchat'
   | 'telegram'
+  | 'jioHotstar'
   | 'unknown';
 
 export interface DeepLinkResult {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,7 +13,7 @@ export type Platform =
   | 'twitch'
   | 'snapchat'
   | 'telegram'
-  | 'jioHotstar'
+  | 'jiohotstar'
   | 'zoom'
   | 'substack'
   | 'unknown';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -32,3 +32,6 @@ export function parseTimestampToSeconds(timestamp: string): number {
 
   return hours * 3600 + minutes * 60 + seconds;
 }
+
+export const getUrlWithoutProtocol = (url: string) =>
+  url.replace(/^https?:\/\//, '').replace(/^www\./, '');


### PR DESCRIPTION
# Pull Request: Add JioHotstar Deep Link Support

## 🎯 Summary
Adds `jiohotstarHandler` to convert JioHotstar web URLs to native app deep links, following the established Spotify/Netflix pattern.

## 📋 Changes

### New Handler: `jiohotstarHandler`
```typescript
// Matches: https://www.hotstar.com/in/shows/1260019000
// Generates: 
//   iOS: hotstar://content/1260019000
//   Android: intent://1260019000#Intent;scheme=hotstar;package=in.startv.hotstar;...
```

**Supported patterns**:
```
✅ https://www.hotstar.com/in/shows/1260019000
✅ https://hotstar.com/movies/1270600012
✅ https://jiohotstar.com/play/abc123xyz  
✅ https://www.hotstar.com/live/cricket-match-456
```


Closes #69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Jio Hotstar deep linking support for iOS and Android.

* **Improvements**
  * Simplified Twitch Android deep link behavior (removed browser fallback parameter).

* **Documentation**
  * Added Jio Hotstar deep link examples and moved the "Unknown URL" section.
  * Updated demo app with a Jio Hotstar example link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->